### PR TITLE
Removed Songea-SZ 71 Mozambique Channel Connection (#1)

### DIFF
--- a/map/games/great_war.xml
+++ b/map/games/great_war.xml
@@ -593,7 +593,6 @@
     <connection t1="SZ 70 Indian Ocean" t2="Dar es Salaam"/>
     <connection t1="SZ 70 Indian Ocean" t2="Songea"/>
     <connection t1="SZ 71 Mozambique Channel" t2="SZ 72 South Atlantic"/>
-    <connection t1="SZ 71 Mozambique Channel" t2="Songea"/>
     <connection t1="SZ 71 Mozambique Channel" t2="Mozambique"/>
     <connection t1="SZ 72 South Atlantic" t2="SZ 73 South Atlantic"/>
     <connection t1="SZ 72 South Atlantic" t2="Namib Desert"/>


### PR DESCRIPTION
This commit fixes the second bug referenced in #1 

(For the first problem, I will comment on the relevant issue on the trilpea-game repository ( triplea-game/triplea#1331) because I am not sure if it affects this map only. 